### PR TITLE
Add option to synchronize updating lambda w/ the gradient step

### DIFF
--- a/latent_rationale/beer/models/latent.py
+++ b/latent_rationale/beer/models/latent.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import numpy as np
 import torch
 from torch import nn
 from latent_rationale.common.util import get_z_stats
@@ -86,6 +87,8 @@ class LatentRationaleModel(nn.Module):
         self.register_buffer('lambda1', torch.full((1,), lambda_init))
         self.register_buffer('c0_ma', torch.full((1,), 0.))  # moving average
         self.register_buffer('c1_ma', torch.full((1,), 0.))  # moving average
+        self.register_buffer('c0_ma_eval', torch.full((1,), 0.))
+        self.register_buffer('c1_ma_eval', torch.full((1,), 0.))
 
     @property
     def z(self):
@@ -112,6 +115,30 @@ class LatentRationaleModel(nn.Module):
         y = self.classifier(x, mask, z)
 
         return y
+
+    def eval(self):
+        """
+        Override eval to additionally reset the moving averages
+        """
+        super(LatentRationaleModel, self).eval()
+        self.c0_ma_eval.fill_(0.)
+        self.c1_ma_eval.fill_(0.)
+
+    def update_lambda(self, i: int, ci: float):
+        assert i == 0 or i == 1
+        lambda_attr = f"lambda{i}"
+        lambda_i = getattr(self, lambda_attr)
+        lambda_i = lambda_i * np.exp(self.lagrange_lr * ci)
+        lambda_i = lambda_i.clamp(self.lambda_min, self.lambda_max)
+        setattr(self, lambda_attr, lambda_i)
+
+    def _update_ma(self, i: int, ci_hat: float):
+        assert i == 0 or i == 1
+        ma_attr = f"c{i}_ma" if self.training else f"c{i}_ma_eval"
+        ma = getattr(self, ma_attr)
+        ma = self.alpha * ma + (1-self.alpha) * ci_hat
+        setattr(self, ma_attr, ma)
+        return ma
 
     def get_loss(self, preds, targets, mask=None):
 
@@ -157,14 +184,14 @@ class LatentRationaleModel(nn.Module):
         c0_hat = (l0 - self.selection)
 
         # moving average of the constraint
-        self.c0_ma = self.alpha * self.c0_ma + (1-self.alpha) * c0_hat.item()
+        c0_ma = self._update_ma(0, c0_hat.item())
 
         # compute smoothed constraint (equals moving average c0_ma)
-        c0 = c0_hat + (self.c0_ma.detach() - c0_hat.detach())
+        c0 = c0_hat + (c0_ma.detach() - c0_hat.detach())
 
         # update lambda
-        self.lambda0 = self.lambda0 * torch.exp(self.lagrange_lr * c0.detach())
-        self.lambda0 = self.lambda0.clamp(self.lambda_min, self.lambda_max)
+        if self.training:
+            self.update_lambda(0, c0.item())
 
         with torch.no_grad():
             optional["cost0_l0"] = l0.item()
@@ -201,15 +228,14 @@ class LatentRationaleModel(nn.Module):
         c1_hat = (lasso_cost - target1)
 
         # update moving average
-        self.c1_ma = self.alpha * self.c1_ma + \
-            (1 - self.alpha) * c1_hat.detach()
+        c1_ma = self._update_ma(1, c1_hat.item())
 
         # compute smoothed constraint
-        c1 = c1_hat + (self.c1_ma.detach() - c1_hat.detach())
+        c1 = c1_hat + (c1_ma.detach() - c1_hat.detach())
 
         # update lambda
-        self.lambda1 = self.lambda1 * torch.exp(self.lagrange_lr * c1.detach())
-        self.lambda1 = self.lambda1.clamp(self.lambda_min, self.lambda_max)
+        if self.training:
+            self.update_lambda(1, c1.item())
 
         with torch.no_grad():
             optional["cost1_lasso"] = lasso_cost.item()

--- a/latent_rationale/beer/models/latent.py
+++ b/latent_rationale/beer/models/latent.py
@@ -45,6 +45,7 @@ class LatentRationaleModel(nn.Module):
                  lambda_init:    float = 0.0015,
                  lambda_min:     float = 1e-12,
                  lambda_max:     float = 5.,
+                 async_lambda:   bool = True,
                  ):
 
         super(LatentRationaleModel, self).__init__()
@@ -63,6 +64,7 @@ class LatentRationaleModel(nn.Module):
         self.lambda_init = lambda_init
         self.lambda_min = lambda_min
         self.lambda_max = lambda_max
+        self.async_lambda = async_lambda
 
         self.z_rnn_size = z_rnn_size
         self.dependent_z = dependent_z
@@ -190,7 +192,7 @@ class LatentRationaleModel(nn.Module):
         c0 = c0_hat + (c0_ma.detach() - c0_hat.detach())
 
         # update lambda
-        if self.training:
+        if self.training and self.async_lambda:
             self.update_lambda(0, c0.item())
 
         with torch.no_grad():
@@ -234,7 +236,7 @@ class LatentRationaleModel(nn.Module):
         c1 = c1_hat + (c1_ma.detach() - c1_hat.detach())
 
         # update lambda
-        if self.training:
+        if self.training and self.async_lambda:
             self.update_lambda(1, c1.item())
 
         with torch.no_grad():

--- a/latent_rationale/beer/models/model_helpers.py
+++ b/latent_rationale/beer/models/model_helpers.py
@@ -41,6 +41,7 @@ def build_model(model_type, vocab, cfg=None):
         lambda_init = cfg["lambda_init"]
         lambda_min = cfg["lambda_min"]
         lambda_max = cfg["lambda_max"]
+        async_lambda = cfg["async_lambda"]
         return LatentRationaleModel(
             vocab_size=vocab_size, emb_size=emb_size, hidden_size=hidden_size,
             output_size=output_size, vocab=vocab, dropout=dropout,
@@ -48,6 +49,7 @@ def build_model(model_type, vocab, cfg=None):
             selection=selection, lasso=lasso,
             lagrange_alpha=lagrange_alpha, lagrange_lr=lagrange_lr,
             lambda_init=lambda_init,
-            lambda_min=lambda_min, lambda_max=lambda_max)
+            lambda_min=lambda_min, lambda_max=lambda_max,
+            async_lambda=async_lambda)
     else:
         raise ValueError("Unknown model")

--- a/latent_rationale/beer/train.py
+++ b/latent_rationale/beer/train.py
@@ -150,11 +150,18 @@ def train():
             assert pad_idx == 1, "pad idx"
             loss, loss_optional = model.get_loss(output, targets, mask=mask)
 
+            # update model parameters
             model.zero_grad()
             loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(),
                                            max_norm=cfg["max_grad_norm"])
             optimizer.step()
+
+            # update lagrange multiplier
+            if not model.async_lambda:
+                model.update_lambda(0, loss_optional["c0"])
+                model.update_lambda(1, loss_optional["c1"])
+
             iter_i += 1
 
             # print info

--- a/latent_rationale/beer/util.py
+++ b/latent_rationale/beer/util.py
@@ -323,6 +323,11 @@ def get_args():
                         help="learning rate for lagrange")
     parser.add_argument('--lagrange_alpha', type=float, default=0.5,
                         help="alpha for computing the running average")
+    parser.add_argument('--sync_lambda', action='store_false',
+                        dest='async_lambda',
+                        help="do not update lambda during the forward pass, "
+                             "instead synchronize the update with the gradient "
+                             "step")
 
     # model / layer
     parser.add_argument('--layer', choices=["lstm", "rcnn"], default="rcnn")


### PR DESCRIPTION
This is a natural follow-up to bastings/interpretable_predictions#4,

Before:
lambda is updated whilst the loss is being computed, effectively leading up to an asynchronous parameter update schema, i.e.
<img src="https://render.githubusercontent.com/render/math?math=(\theta_t, \lambda_t) \rightarrow (\theta_t, \lambda_{t%2B1}) \rightarrow (\theta_{t%2B1}, \lambda_{t%2B1}) \rightarrow \dots ">

After:
synchronize both updates, i.e. <img src="https://render.githubusercontent.com/render/math?math=(\theta_t, \lambda_t) \rightarrow (\theta_{t%2B1}, \lambda_{t%2B1}) \rightarrow \dots ">

From my limited testing, this doesn't seem to make a big difference empirically though.

@bastings What do you reckon?